### PR TITLE
Fix: unified focus behavior across all panels using shared lastRow()

### DIFF
--- a/src/main/java/uk/ac/ncl/dwa/view/FocusUtils.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/FocusUtils.java
@@ -1,0 +1,27 @@
+package uk.ac.ncl.dwa.view;
+
+import javax.swing.*;
+
+public final class FocusUtils {
+	private FocusUtils() {}
+
+	public static void lastRow(JTable table, JScrollPane scrollPane) {
+		SwingUtilities.invokeLater(() -> {
+			int lastRow = table.getRowCount() - 1;
+			if (lastRow >= 0) {
+				table.setRowSelectionInterval(lastRow, lastRow);
+				table.scrollRectToVisible(table.getCellRect(lastRow, 0, true));
+				table.requestFocusInWindow();
+			}
+
+			JScrollBar vertical = scrollPane.getVerticalScrollBar();
+			vertical.setValue(vertical.getMaximum());
+		});
+	}
+
+	public static int getLastRowIndex(JTable table) {
+		return table.getRowCount() - 1;
+	}
+}
+
+

--- a/src/main/java/uk/ac/ncl/dwa/view/HelperPanel.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/HelperPanel.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.ncl.dwa.model.Helper;
 import uk.ac.ncl.dwa.model.Helpers;
 import javax.swing.*;
+import static uk.ac.ncl.dwa.view.FocusUtils.lastRow;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -73,7 +74,7 @@ public class HelperPanel extends JPanel implements ActionListener {
             case "Add" -> {
                 logger.info("Adding new Person");
                 helpers.add(helpers.size(), new Helper());
-
+                lastRow(helperTable, scrollPane);
             }
             case "Delete" -> {
                   int row = helperTable.getSelectedRow();
@@ -89,19 +90,7 @@ public class HelperPanel extends JPanel implements ActionListener {
                 helperTable.loadInstructors();
             }
         }
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = helperTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                helperTable.setRowSelectionInterval(lastRow, lastRow);
-                helperTable.scrollRectToVisible(helperTable.getCellRect(lastRow, 0, true));
-                helperTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = scrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
+        
         helperTable.revalidate();
         helperTable.repaint();
     }

--- a/src/main/java/uk/ac/ncl/dwa/view/InstructorPanel.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/InstructorPanel.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.ncl.dwa.model.Instructor;
 import uk.ac.ncl.dwa.model.Instructors;
 import javax.swing.*;
+import static uk.ac.ncl.dwa.view.FocusUtils.lastRow;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -77,7 +78,7 @@ public class InstructorPanel extends JPanel implements ActionListener {
             case "Add" -> {
                 // Add action
                 instructors.add(instructors.size(), new Instructor());
-
+                lastRow(instructorTable, scrollPane);
             }
             case "Delete" -> {
                 // Delete action
@@ -94,32 +95,7 @@ public class InstructorPanel extends JPanel implements ActionListener {
                 instructorTable.loadWorkshopSlugs();
             }
         }
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = instructorTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                instructorTable.setRowSelectionInterval(lastRow, lastRow);
-                instructorTable.scrollRectToVisible(instructorTable.getCellRect(lastRow, 0, true));
-                instructorTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = scrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = instructorTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                instructorTable.setRowSelectionInterval(lastRow, lastRow);
-                instructorTable.scrollRectToVisible(instructorTable.getCellRect(lastRow, 0, true));
-                instructorTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = scrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
+        
         instructorTable.revalidate();
         instructorTable.repaint();
     }

--- a/src/main/java/uk/ac/ncl/dwa/view/PersonPanel.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/PersonPanel.java
@@ -7,6 +7,7 @@ import uk.ac.ncl.dwa.database.SpecificQueriesHelper;
 import uk.ac.ncl.dwa.model.People;
 import uk.ac.ncl.dwa.model.Person;
 import javax.swing.*;
+import static uk.ac.ncl.dwa.view.FocusUtils.lastRow;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -77,7 +78,7 @@ public class PersonPanel extends JPanel implements ActionListener {
             case "Add" -> {
                 logger.info("Adding new Person");
                 people.add(people.size(), new Person());
-
+                lastRow(personTable, personTableScrollPane);
             }
             case "Delete" -> {
                 int row =  personTable.getSelectedRow();
@@ -100,19 +101,7 @@ public class PersonPanel extends JPanel implements ActionListener {
                 }
             }
         }
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = personTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                personTable.setRowSelectionInterval(lastRow, lastRow);
-                personTable.scrollRectToVisible(personTable.getCellRect(lastRow, 0, true));
-                personTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = personTableScrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
+        
         personTable.revalidate();
         personTable.repaint();
     }

--- a/src/main/java/uk/ac/ncl/dwa/view/RoomPanel.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/RoomPanel.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.ncl.dwa.model.Room;
 import uk.ac.ncl.dwa.model.Rooms;
 import javax.swing.*;
+import static uk.ac.ncl.dwa.view.FocusUtils.lastRow;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -73,6 +74,7 @@ public class RoomPanel extends JPanel implements ActionListener {
                 rooms.add(rooms.size(), new Room());
                 roomTable.revalidate();
                 roomTable.repaint();
+                lastRow(roomTable, scrollPane);
             }
             case "Delete" -> {
                 int row = roomTable.getSelectedRow();
@@ -88,19 +90,7 @@ public class RoomPanel extends JPanel implements ActionListener {
                 }
             }
         }
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = roomTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                roomTable.setRowSelectionInterval(lastRow, lastRow);
-                roomTable.scrollRectToVisible(roomTable.getCellRect(lastRow, 0, true));
-                roomTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = scrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
+        
         roomTable.revalidate();
         roomTable.repaint();
     }

--- a/src/main/java/uk/ac/ncl/dwa/view/SettingPanel.java
+++ b/src/main/java/uk/ac/ncl/dwa/view/SettingPanel.java
@@ -9,6 +9,7 @@ import uk.ac.ncl.dwa.model.Setting;
 import uk.ac.ncl.dwa.model.Settings;
 
 import javax.swing.*;
+import static uk.ac.ncl.dwa.view.FocusUtils.lastRow;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -82,6 +83,7 @@ public class SettingPanel extends JPanel implements ActionListener {
             case "Add Setting" -> {
                 logger.info("Adding new Setting");
                 settings.add(settings.size(), new Setting());
+                lastRow(settingTable, settingsScrollPane);
             }
             case "Delete Setting" -> {
                 int row = settingTable.getSelectedRow();
@@ -97,19 +99,7 @@ public class SettingPanel extends JPanel implements ActionListener {
                 JOptionPane.showMessageDialog(this, "You have to restart the program for the properties changes to take effect");
             }
         }
-        // Ensure the table scrolls to and focuses on the last row
-        SwingUtilities.invokeLater(() -> {
-            int lastRow = settingTable.getRowCount() - 1;
-            if (lastRow >= 0) {
-                settingTable.setRowSelectionInterval(lastRow, lastRow);
-                settingTable.scrollRectToVisible(settingTable.getCellRect(lastRow, 0, true));
-                settingTable.requestFocusInWindow();
-            }
-
-            // Make sure the scrollbars are scrolled all the way to the bottom
-            JScrollBar vertical = settingsScrollPane.getVerticalScrollBar();
-            vertical.setValue(vertical.getMaximum());
-        });
+        
         settingTable.revalidate();
         settingTable.repaint();
     }


### PR DESCRIPTION
This PR fixes the focus jump issue when using "Delete GitHub Repository",
"Generate", and "Clone" buttons.

- Moved lastRow() into a new shared UIUtils class.
- Updated all panels to use the common method.
- Tested across Workshop, Instructor, and Learner tabs.

Fixes: #29 